### PR TITLE
fix: removed union and mixed types

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Bank Transfer | Cartasi | GivaCard | SprayPay | Przelewy24 |
 
 # Requirements
 
-    PHP 5.6 or higher
+    PHP 7.4 or higher
 
 
 # Installation

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Pay.nl driver for the Omnipay PHP payment processing library based on the V3 PayNL orders API",
     "type": "library",
     "require": {
+        "php": ">=7.4",
         "omnipay/common": "^3.3",
         "ext-json": "*"
     },

--- a/src/Internal/PayOrderNotFoundResponse.php
+++ b/src/Internal/PayOrderNotFoundResponse.php
@@ -4,7 +4,10 @@ namespace Omnipay\PaynlV3\Internal;
 
 class PayOrderNotFoundResponse {
 
-    protected mixed $data;
+    /**
+     * @var array|null
+     */
+    protected $data;
     private $orderNotFoundStatusCode = 'PAY-2001';
 
     public function __construct($data)

--- a/src/Message/Request/PurchaseRequest.php
+++ b/src/Message/Request/PurchaseRequest.php
@@ -74,8 +74,8 @@ class PurchaseRequest extends AbstractPaynlRequest
             $data['order']['countryCode'] = !empty($card->getCountry()) ? substr($card->getCountry(), 0, 2) : null;
             $data['order']['invoiceAddress']['firstName'] = $card->getBillingFirstName();
             $data['order']['invoiceAddress']['lastName'] = $card->getBillingLastName();
-            $data['order']['invoiceAddress']['street'] = $billingAddressParts[1];
-            $data['order']['invoiceAddress']['streetNumber'] = $billingAddressParts[2];
+            $data['order']['invoiceAddress']['street'] = isset($billingAddressParts[1]) ? $billingAddressParts[1] : null;
+            $data['order']['invoiceAddress']['streetNumber'] = isset($billingAddressParts[2]) ? $billingAddressParts[2] : null;
             $data['order']['invoiceAddress']['streetNumberExtension'] = isset($billingAddressParts[3]) ? $billingAddressParts[3] : null;
             $data['order']['invoiceAddress']['zipCode'] = $card->getBillingPostcode();
             $data['order']['invoiceAddress']['city'] = $card->getBillingCity();
@@ -84,8 +84,8 @@ class PurchaseRequest extends AbstractPaynlRequest
 
             $data['order']['deliveryAddress']['firstName'] = $card->getShippingFirstName();
             $data['order']['deliveryAddress']['lastName'] = $card->getShippingLastName();
-            $data['order']['deliveryAddress']['street'] = $shippingAddressParts[1];
-            $data['order']['deliveryAddress']['streetNumber'] = $shippingAddressParts[2];
+            $data['order']['deliveryAddress']['street'] = isset($shippingAddressParts[1]) ? $shippingAddressParts[1] : null;
+            $data['order']['deliveryAddress']['streetNumber'] = isset($shippingAddressParts[2]) ? $shippingAddressParts[2] : null;
             $data['order']['deliveryAddress']['streetNumberExtension'] = isset($shippingAddressParts[3]) ? $shippingAddressParts[3] : null;
             $data['order']['deliveryAddress']['zipCode'] = $card->getShippingPostcode();
             $data['order']['deliveryAddress']['city'] = $card->getShippingCity();

--- a/src/Message/Request/RefundRequest.php
+++ b/src/Message/Request/RefundRequest.php
@@ -27,7 +27,7 @@ class RefundRequest extends AbstractPaynlRequest
      */
     public function sendData($data)
     {
-        $responseData = $this->sendRequestRestApi('transactions/' . $data['id'] . '/refund', method: 'PATCH');
+        $responseData = $this->sendRequestRestApi('transactions/' . $data['id'] . '/refund', null, 'PATCH');
         return $this->response = new RefundResponse($this, $responseData);
     }
 }

--- a/src/Message/Request/VoidRequest.php
+++ b/src/Message/Request/VoidRequest.php
@@ -34,7 +34,7 @@ class VoidRequest extends AbstractPaynlRequest
     {
         $voidUrl = '/' . $data['id'] . '/void';
 
-        $responseData = $this->sendRequestMultiCore($voidUrl, method: 'PATCH');
+        $responseData = $this->sendRequestMultiCore($voidUrl, null, 'PATCH');
         return $this->response = new VoidResponse($this, $responseData);
     }
 }

--- a/src/Message/Response/FetchServiceConfigResponse.php
+++ b/src/Message/Response/FetchServiceConfigResponse.php
@@ -7,7 +7,10 @@ use Omnipay\Common\Message\RequestInterface;
 class FetchServiceConfigResponse {
 
     protected RequestInterface $request;
-    protected mixed $data;
+    /**
+     * @var array|null
+     */
+    protected $data;
 
     public function __construct(RequestInterface $request, $data)
     {


### PR DESCRIPTION
V3 breaks older versions of php due to the mixed type not being available. Also, not providing enough address details causes the request to fail with an `Undefined offset: 1` 

Added the minimum required PHP version of 7.4 to the composer file. If this change is undesired and thus PHP 7.4 is not supported, can you add a minimum required PHP version to the composer file? 